### PR TITLE
AQ-77_intro_page_logic

### DIFF
--- a/quiz/web/src/modules/Start/Start.tsx
+++ b/quiz/web/src/modules/Start/Start.tsx
@@ -68,12 +68,14 @@ function Start() {
                 />
                 <Typography align="center" variant="body1">
                     Dobre nazwy są krótkie i łatwe do zapamiętania! Potrzebujesz inspiracji? Co ty na{" "}
-                    <span
-                        style={{ color: "green", cursor: "pointer" }}
+                    <button
+                        type="button"
+                        style={{ color: "green", cursor: "pointer", border: "none" }}
                         onClick={() => setUserNickname(suggestedNickname)}
+                        onKeyUp={() => setUserNickname(suggestedNickname)}
                     >
                         {suggestedNickname}
-                    </span>
+                    </button>
                     ?
                 </Typography>
                 <Button

--- a/quiz/web/src/modules/Start/Start.tsx
+++ b/quiz/web/src/modules/Start/Start.tsx
@@ -1,20 +1,34 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Typography from "@mui/material/Typography";
 import InputAdornment from "@mui/material/InputAdornment";
 import IconButton from "@mui/material/IconButton";
 import CachedIcon from "@mui/icons-material/Cached";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
+import { faker } from "@faker-js/faker";
 import NavBar from "./NavBar";
 
 function Start() {
-    const [nickname, setNickname] = useState("");
+    const [userNickname, setUserNickname] = useState("");
+    const [suggestedNickname, setSuggestedNickname] = useState("");
 
+    function generateSuggestedNickname() {
+        const generatedNickname = faker.internet.userName();
+        setSuggestedNickname(generatedNickname);
+    }
+
+    useEffect(() => {
+        generateSuggestedNickname();
+    }, []);
+
+    useEffect(() => {
+        setUserNickname(suggestedNickname);
+    }, [suggestedNickname]);
     return (
         <div className="container h-screen">
             <NavBar />
-            <div className="flex flex-col items-center content-center my-5 mt-9">
-                <Typography className="mb-3" variant="h2" gutterBottom>
+            <div className="flex flex-col items-center content-center m-5 mt-9">
+                <Typography className="mb-3" variant="h4" gutterBottom>
                     Witaj!
                 </Typography>
                 <Typography variant="subtitle1" gutterBottom>
@@ -27,12 +41,19 @@ function Start() {
                     helperText="Nazwę zawsze możesz zmienić"
                     variant="filled"
                     size="small"
-                    value={nickname}
-                    onChange={(event) => setNickname(event.target.value)}
+                    value={userNickname}
+                    onChange={(event) => setUserNickname(event.target.value)}
                     InputProps={{
                         endAdornment: (
                             <InputAdornment position="end">
-                                <IconButton type="button" aria-label="search">
+                                <IconButton
+                                    type="button"
+                                    aria-label="search"
+                                    onClick={() => {
+                                        generateSuggestedNickname();
+                                        setUserNickname(suggestedNickname);
+                                    }}
+                                >
                                     <CachedIcon className="text-primary70" fontSize="large" />
                                 </IconButton>
                             </InputAdornment>
@@ -44,7 +65,21 @@ function Start() {
                         "& .MuiFormHelperText-root ": { textAlign: "center" },
                     }}
                 />
-                <Button variant="contained" className="bg-primary40 rounded-full mt-6" disabled={!nickname}>
+                <Typography align="center" variant="body1">
+                    Dobre nazwy są krótkie i łatwe do zapamiętania! Potrzebujesz inspiracji? Co ty na{" "}
+                    <span
+                        style={{ color: "green", cursor: "pointer" }}
+                        onClick={() => setUserNickname(suggestedNickname)}
+                    >
+                        {suggestedNickname}
+                    </span>
+                    ?
+                </Typography>
+                <Button
+                    variant="contained"
+                    className="bg-primary40 rounded-full mt-6"
+                    disabled={!userNickname || userNickname.length <= 3}
+                >
                     Zacznij grać
                 </Button>
                 <Button variant="contained" className="bg-secondary90 rounded-full mt-16 text-black">

--- a/quiz/web/src/modules/Start/Start.tsx
+++ b/quiz/web/src/modules/Start/Start.tsx
@@ -1,12 +1,15 @@
+import { useState } from "react";
 import Typography from "@mui/material/Typography";
 import InputAdornment from "@mui/material/InputAdornment";
 import IconButton from "@mui/material/IconButton";
 import CachedIcon from "@mui/icons-material/Cached";
-import TextField from "@mui/material/TextField";
 import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
 import NavBar from "./NavBar";
 
 function Start() {
+    const [nickname, setNickname] = useState("");
+
     return (
         <div className="container h-screen">
             <NavBar />
@@ -21,9 +24,11 @@ function Start() {
                     id="standard-helperText"
                     className="pt-10"
                     placeholder="losowa nazwa"
-                    helperText="Nazwę - zawsze możesz zmienić"
+                    helperText="Nazwę zawsze możesz zmienić"
                     variant="filled"
                     size="small"
+                    value={nickname}
+                    onChange={(event) => setNickname(event.target.value)}
                     InputProps={{
                         endAdornment: (
                             <InputAdornment position="end">
@@ -39,7 +44,7 @@ function Start() {
                         "& .MuiFormHelperText-root ": { textAlign: "center" },
                     }}
                 />
-                <Button variant="contained" className="bg-primary40 rounded-full mt-6">
+                <Button variant="contained" className="bg-primary40 rounded-full mt-6" disabled={!nickname}>
                     Zacznij grać
                 </Button>
                 <Button variant="contained" className="bg-secondary90 rounded-full mt-16 text-black">

--- a/quiz/web/src/modules/Start/Start.tsx
+++ b/quiz/web/src/modules/Start/Start.tsx
@@ -6,6 +6,7 @@ import CachedIcon from "@mui/icons-material/Cached";
 import Button from "@mui/material/Button";
 import TextField from "@mui/material/TextField";
 import { faker } from "@faker-js/faker";
+import { Link } from "react-router-dom";
 import NavBar from "./NavBar";
 
 function Start() {
@@ -83,10 +84,10 @@ function Start() {
                     Zacznij grać
                 </Button>
                 <Button variant="contained" className="bg-secondary90 rounded-full mt-16 text-black">
-                    Logowanie
+                    <Link to="/login">Logowanie</Link>
                 </Button>
                 <Button variant="contained" className="bg-secondary90 rounded-full mt-9 text-black">
-                    Rejestracja
+                    <Link to="/register">Rejestracja</Link>
                 </Button>
             </div>
         </div>


### PR DESCRIPTION
# Description

Users can now generate fake nicknames and use them as their own.
Users cannot click "play"(the button is disabled) until a nickname is provided, and its length is over 3 letters.
Users can re-generate fake nicknames.
According to the directions, it looks in the way, that GitHub is suggesting repository names. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The related memme has been added

![image](https://user-images.githubusercontent.com/90700152/230146536-559f866c-536a-4b21-b2dc-1bcffaa0778e.png)
