### PR TITLE
FM-26_image_picker

### DIFF
--- a/flashcards/web/src/modules/AddDeck/AddDeckTemp.tsx
+++ b/flashcards/web/src/modules/AddDeck/AddDeckTemp.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react";
+import ImagePicker from "./ImagePicker";
+
+function AddDeck() {
+    const [selectedImage, setSelectedImage] = useState<string | null>(null);
+
+    return (
+        <div
+            style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                minHeight: "100vh",
+                background: "radial-gradient(circle at center, #2D4E9D 50%, #273569)",
+            }}
+        >
+            <h1 style={{ fontSize: "2rem", color: "white" }}>Dodaj nowy deck</h1>
+            <div
+                style={{
+                    maxWidth: "600px",
+                    width: "100%",
+                    backgroundColor: "#2c3e5080",
+                    borderRadius: "15px",
+                    marginTop: "1rem",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    overflow: "hidden",
+                }}
+            >
+                <div
+                    style={{
+                        backgroundImage: selectedImage ? `url(${selectedImage})` : "none",
+                        backgroundPosition: "center",
+                        backgroundRepeat: "no-repeat",
+                        backgroundSize: "cover",
+                        position: "relative",
+                        maxWidth: "100%",
+                        width: "100%",
+                        height: "164px",
+                    }}
+                />
+                <form
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        marginTop: "1rem",
+                        marginBottom: "1rem",
+                        width: "100%",
+                        padding: "0 1rem",
+                    }}
+                >
+                    <label htmlFor="deckName" style={{ fontSize: "1.25rem", color: "white" }}>
+                        Nazwa decka:
+                    </label>
+                    <input
+                        type="text"
+                        id="deckName"
+                        name="deckName"
+                        style={{
+                            fontSize: "1.25rem",
+                            padding: "0.5rem",
+                            borderRadius: "5px",
+                            width: "100%",
+                            marginBottom: "1rem",
+                        }}
+                    />
+                    <label htmlFor="category" style={{ fontSize: "1.25rem", color: "white" }}>
+                        Kategoria:
+                    </label>
+                    <select
+                        id="category"
+                        name="category"
+                        style={{
+                            fontSize: "1.25rem",
+                            padding: "0.5rem",
+                            borderRadius: "5px",
+                            width: "100%",
+                        }}
+                    >
+                        <option value="javascript">JavaScript</option>
+                        <option value="python">Python</option>
+                        <option value="react">React</option>
+                        <option value="node">Node.js</option>
+                        <option value="ruby">Ruby</option>
+                    </select>
+                </form>
+            </div>
+            <ImagePicker setSelectedImage={setSelectedImage} />
+        </div>
+    );
+}
+
+export default AddDeck;

--- a/flashcards/web/src/modules/AddDeck/ImagePicker.tsx
+++ b/flashcards/web/src/modules/AddDeck/ImagePicker.tsx
@@ -1,0 +1,204 @@
+import { Container, styled } from "@mui/material";
+import { useEffect, useState } from "react";
+import { faker } from "@faker-js/faker";
+import PreviewImageLibrary from "./PreviewImageLibrary";
+import ModalImageLibrary from "./ModalImageLibrary";
+
+const StyledInput = styled("div")({
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    height: "164px",
+    backgroundColor: "#2c3e5080",
+    borderRadius: "15px",
+    marginTop: "1rem",
+    cursor: "pointer",
+    transition: "all .3s ease-in-out",
+    "&:hover": {
+        backgroundColor: "#2c3e50b0",
+    },
+});
+
+const ImagePickerIcon = styled("div")({
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: "48px",
+    height: "48px",
+    borderRadius: "50%",
+    backgroundColor: "#FFFFFF",
+    color: "#2D4E9D",
+    fontSize: "2rem",
+    transition: "all .3s ease-in-out",
+    marginBottom: "0.5rem",
+    "&:hover": {
+        transform: "scale(1.1)",
+    },
+});
+
+const ImagePickerText = styled("div")({
+    color: "#FFFFFF",
+    fontSize: "1.25rem",
+    textAlign: "center",
+    marginBottom: "1rem",
+    transition: "all .3s ease-in-out",
+});
+
+interface ImagePickerProps {
+    setSelectedImage: (image: string | null) => void;
+}
+
+export type Image = {
+    images: string[];
+};
+
+function ImagePicker({ setSelectedImage }: ImagePickerProps) {
+    const [showModal, setShowModal] = useState<boolean>(false);
+    const [images, setImages] = useState<string[]>([]);
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [isDragging, setIsDragging] = useState<boolean>(false);
+
+    // Funkcja obsługująca ustawienie wybranego obrazka z biblioteki
+    const handleImageSelect = (image: string | null) => {
+        setSelectedImage(image);
+        setShowModal(false);
+    };
+
+    // Pobieranie obrazów z serwera, tymczasowo używając biblioteki faker
+    useEffect(() => {
+        const fetchImages = async () => {
+            try {
+                setIsLoading(true);
+                // Tworzenie tymczasowej tablicy obrazów za pomocą biblioteki faker
+                const fakerImages = Array.from({ length: 10 }).map(() => faker.image.technics(300, 200, true));
+                setImages(fakerImages);
+            } catch (error) {
+                console.error("Error fetching images:", error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        fetchImages();
+    }, []);
+
+    const isImageValid = (file: File): boolean => {
+        // Sprawdź rozszerzenie pliku
+        const validImageExtensions = ["image/jpeg", "image/png"];
+        if (!validImageExtensions.includes(file.type)) {
+            alert("Niewłaściwy format obrazka! Obsługiwane formaty to: JPEG i PNG");
+            return false;
+        }
+
+        // Sprawdź wielkość pliku (ograniczenie do 5 MB)
+        const maxFileSize = 5 * 1024 * 1024; // 5 MB
+        if (file.size > maxFileSize) {
+            alert("Plik jest zbyt duży! Maksymalny rozmiar pliku to 5 MB.");
+            return false;
+        }
+
+        return true;
+    };
+    const handleImageDrop = (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        setIsDragging(false);
+        const image = e.dataTransfer.files[0];
+
+        if (image && isImageValid(image)) {
+            const reader = new FileReader();
+
+            reader.onload = () => {
+                setSelectedImage(reader.result as string);
+            };
+
+            reader.readAsDataURL(image);
+        }
+    };
+
+    const handleDragEnter = (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+        e.preventDefault();
+        setIsDragging(false);
+    };
+
+    const handleImageInputClick = () => {
+        // Tworzenie ukrytego elementu input do wyboru plików
+        const fileInput = document.createElement("input");
+        fileInput.type = "file";
+        fileInput.accept = "image/jpeg, image/png";
+
+        // Obsługa zdarzenia zmiany (wyboru pliku) w elemencie input
+        fileInput.onchange = (event) => {
+            // Rzutowanie event.target na HTMLInputElement, aby uzyskać dostęp do właściwości files
+            const target = event.target as HTMLInputElement;
+
+            // Sprawdzanie, czy istnieje plik i czy istnieje więcej niż jeden plik
+            const { files } = target;
+
+            if (!files || files.length === 0) {
+                return;
+            }
+
+            // Jeśli obraz jest prawidłowy, wczytujemy go jako DataURL
+            const image = files[0];
+            if (isImageValid(image)) {
+                const reader = new FileReader();
+                reader.onload = () => {
+                    setSelectedImage(reader.result as string);
+                };
+                reader.readAsDataURL(image);
+            }
+        };
+
+        // Wywołanie kliknięcia na ukrytym elemencie input, aby otworzyć okno wyboru plików
+        fileInput.click();
+    };
+
+    return (
+        <Container>
+            <h2 style={{ fontSize: "1.5rem", color: "white", textAlign: "center", marginBottom: "1rem" }}>
+                Wybierz obrazek (opcjonalne)
+            </h2>
+            <StyledInput
+                style={{
+                    maxWidth: "600px",
+                    margin: "auto",
+                    marginBottom: "1rem",
+                    backgroundColor: isDragging ? "#2c3e50c0" : undefined, // Zmień backgroundColor, gdy obrazek jest przeciągany
+                }}
+                onDrop={handleImageDrop}
+                onDragOver={(e) => e.preventDefault()}
+                onDragEnter={handleDragEnter}
+                onDragLeave={handleDragLeave}
+                onClick={handleImageInputClick}
+            >
+                <ImagePickerIcon className="image-picker-icon">+</ImagePickerIcon>
+                <ImagePickerText className="image-picker-text">Kliknij lub przeciągnij i upuść</ImagePickerText>
+            </StyledInput>
+
+            {/* Wybór obrazka z biblioteki */}
+            <PreviewImageLibrary
+                images={images}
+                isLoading={isLoading}
+                setIsLoading={setIsLoading}
+                setShowModal={setShowModal}
+            />
+            {/* Wyświetlanie modalu z biblioteką obrazów */}
+            {showModal && (
+                <ModalImageLibrary
+                    images={images}
+                    handleImageSelect={handleImageSelect}
+                    closeLibrary={() => setShowModal(false)}
+                />
+            )}
+        </Container>
+    );
+}
+
+export default ImagePicker;

--- a/flashcards/web/src/modules/AddDeck/ModalImageLibrary.tsx
+++ b/flashcards/web/src/modules/AddDeck/ModalImageLibrary.tsx
@@ -1,0 +1,141 @@
+import { useState } from "react";
+import { Grid, Box, IconButton, Typography } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { Image } from "./ImagePicker";
+
+interface ModalImageLibraryProps {
+    images: Image["images"];
+    handleImageSelect: (image: string | null) => void;
+    closeLibrary: () => void;
+}
+
+function ModalImageLibrary({ images, handleImageSelect, closeLibrary }: ModalImageLibraryProps) {
+    const [clickedImage, setClickedImage] = useState<string | null>(null);
+
+    const handleImageClick = (image: string) => {
+        setClickedImage(image);
+    };
+
+    return (
+        <Box
+            sx={{
+                position: "fixed",
+                top: 0,
+                left: 0,
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                justifyContent: "center",
+                alignItems: "center",
+                background: "rgba(0, 0, 0, 0.5)",
+            }}
+            onClick={closeLibrary}
+        >
+            <Box
+                sx={{
+                    position: "relative",
+                    width: "100%",
+                    maxWidth: "800px",
+                    backgroundColor: "#29455B",
+                    borderRadius: "25px",
+                    padding: "16px",
+                    cursor: "default",
+                }}
+                onClick={(e) => e.stopPropagation()}
+            >
+                <Grid container spacing={1}>
+                    {images.map((item) => (
+                        <Grid item xs={12} sm={6} md={4} key={item}>
+                            <button
+                                type="button"
+                                onClick={() => handleImageClick(item)}
+                                style={{
+                                    border: "none",
+                                    background: "none",
+                                    padding: 0,
+                                    margin: 0,
+                                    cursor: "pointer",
+                                    outline: "none",
+                                }}
+                            >
+                                <img
+                                    src={item}
+                                    alt={item}
+                                    style={{
+                                        width: "100%",
+                                        borderRadius: "15px",
+                                        border: clickedImage === item ? "4px solid #FBB916" : "4px solid #19344A",
+                                        boxSizing: "border-box",
+                                        transition: "0.3s",
+                                    }}
+                                    onMouseEnter={(e) => {
+                                        if (clickedImage !== item) {
+                                            e.currentTarget.style.border = "4px solid #CAA815";
+                                        }
+                                    }}
+                                    onMouseLeave={(e) => {
+                                        if (clickedImage !== item) {
+                                            e.currentTarget.style.border = "4px solid #19344A";
+                                        }
+                                    }}
+                                />
+                            </button>
+                        </Grid>
+                    ))}
+                </Grid>
+                <IconButton
+                    sx={{
+                        position: "absolute",
+                        top: "-16px",
+                        right: "-16px",
+                        background: "#FDFEFD",
+                        color: "black",
+                        "&:hover": {
+                            background: "#e0e0e0",
+                        },
+                    }}
+                    onClick={closeLibrary}
+                >
+                    <CloseIcon />
+                </IconButton>
+                {clickedImage && (
+                    <button
+                        type="button"
+                        onClick={() => handleImageSelect(clickedImage)}
+                        style={{
+                            position: "absolute",
+                            bottom: "8px",
+                            right: "8px",
+                            background: "#FAA815",
+                            color: "white",
+                            borderRadius: "25px",
+                            border: "none",
+                            padding: "8px 16px",
+                            cursor: "pointer",
+                            fontSize: "16px",
+                            opacity: "0.9",
+                            transition: "0.3s",
+                        }}
+                        onMouseEnter={(e) => {
+                            e.currentTarget.style.opacity = "1";
+                        }}
+                        onMouseLeave={(e) => {
+                            e.currentTarget.style.opacity = "0.9";
+                        }}
+                    >
+                        {/* Przycisk wybierz zamknięty w tagy typography, style bold */}
+                        <Typography
+                            variant="h6"
+                            component="h2"
+                            sx={{ color: "white", position: "relative", fontWeight: "bold" }}
+                        >
+                            Wybierz
+                        </Typography>
+                    </button>
+                )}
+            </Box>
+        </Box>
+    );
+}
+
+export default ModalImageLibrary;

--- a/flashcards/web/src/modules/AddDeck/PreviewImageLibrary.tsx
+++ b/flashcards/web/src/modules/AddDeck/PreviewImageLibrary.tsx
@@ -1,0 +1,93 @@
+import { CircularProgress, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+import { faker } from "@faker-js/faker";
+import { Image } from "./ImagePicker";
+
+interface LibraryImageListProps {
+    setShowModal: (showModal: boolean) => void;
+    images: Image["images"];
+    setIsLoading: (isLoading: boolean) => void;
+    isLoading: boolean;
+}
+
+function PreviewImageLibrary({ images, isLoading, setIsLoading, setShowModal }: LibraryImageListProps) {
+    const [previewImages, setPreviewImages] = useState<string[]>([]);
+
+    useEffect(() => {
+        const fetchImages = async () => {
+            try {
+                const fakerImages = Array.from({ length: 3 }).map(() => {
+                    return faker.image.technics(300, 200, true);
+                });
+                console.log(fakerImages);
+                setPreviewImages(fakerImages);
+            } catch (error) {
+                console.error("Error fetching images:", error);
+            }
+        };
+
+        fetchImages();
+    }, []);
+
+    const handleShowModal = () => {
+        setIsLoading(true);
+        setTimeout(() => {
+            setShowModal(true);
+            setIsLoading(false);
+        }, 1000);
+    };
+
+    return (
+        <div
+            onClick={handleShowModal}
+            style={{
+                position: "relative",
+                display: "flex",
+                maxWidth: "600px",
+                margin: "auto",
+                borderRadius: "25px",
+                overflow: "hidden",
+                cursor: "pointer",
+            }}
+        >
+            {previewImages.map((image) => (
+                <div
+                    key={image}
+                    style={{
+                        backgroundImage: `url(${image})`,
+                        backgroundPosition: "center",
+                        backgroundRepeat: "no-repeat",
+                        backgroundSize: "cover",
+                        position: "relative",
+                        maxWidth: "200px",
+                        width: "100%",
+                        height: "164px",
+                    }}
+                />
+            ))}
+            <div
+                style={{
+                    backgroundColor: "rgba(0, 0, 0, 0.5)",
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    bottom: 0,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                }}
+            >
+                {isLoading ? (
+                    <CircularProgress color="warning" />
+                ) : (
+                    <Typography variant="h6" component="h2" sx={{ color: "white", position: "absolute" }}>
+                        Przeglądaj obrazy
+                    </Typography>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default PreviewImageLibrary;

--- a/flashcards/web/src/modules/AddDeck/index.ts
+++ b/flashcards/web/src/modules/AddDeck/index.ts
@@ -1,0 +1,3 @@
+import AddDeck from "./AddDeck";
+
+export default AddDeck;

--- a/flashcards/web/src/router.tsx
+++ b/flashcards/web/src/router.tsx
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from "react-router-dom";
+import AddDeckTemp from "./modules/AddDeck/AddDeckTemp";
 
 // eslint-disable-next-line import/prefer-default-export
 export const router = createBrowserRouter([
@@ -9,5 +10,9 @@ export const router = createBrowserRouter([
     {
         path: "/login",
         element: <h1>Login</h1>,
+    },
+    {
+        path: "/add-deck",
+        element: <AddDeckTemp />,
     },
 ]);


### PR DESCRIPTION
# Description

This pull request includes the implementation of image selection functionality in the AddDeckTemp component (a temporary template addDeck component created since the actual AddDeck component doesn't exist yet). The image selection functionality utilizes ImagePicker, ModalImageLibrary, and PreviewImageLibrary components. Backend API for image handling does not exist yet, so faker is used to generate images for now. The code is refactored for improved usability and code clarity, and sample styles are added. Drag-and-drop functionality is added, and the AddDeck component is exported as default in index.ts for easier imports. Additionally, the router configuration is updated to include a new route for /add-deck.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The related memme has been added

![frontend ready](https://i.imgur.com/jOgWUfB.jpeg)
