### PR TITLE
AQ-108 Fix coverage bug

### DIFF
--- a/flashcards/web/.eslintrc.json
+++ b/flashcards/web/.eslintrc.json
@@ -32,6 +32,7 @@
                 "extensions": [".tsx", ".ts"]
             }
         ],
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
         "import/extensions": [
             "error",
             "ignorePackages",

--- a/flashcards/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/flashcards/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it } from "vitest";
+import { screen, render } from "@testing-library/react";
+import { ErrorBoundary } from "modules/common/components";
+
+describe("ErrorBoundary", () => {
+    it("Displays error message after catching error", () => {
+        const ThrowError = () => {
+            throw new Error("Random Error");
+        };
+
+        render(
+            <ErrorBoundary>
+                <ThrowError />
+            </ErrorBoundary>
+        );
+
+        expect(screen.getByRole("h1").textContent).toBe("Sorry");
+        expect(screen.getByRole("p").textContent).toBe("Something went wrong, please try again");
+    });
+});

--- a/flashcards/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/flashcards/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -14,7 +14,7 @@ describe("ErrorBoundary", () => {
             </ErrorBoundary>
         );
 
-        expect(screen.getByRole("h1").textContent).toBe("Sorry");
-        expect(screen.getByRole("p").textContent).toBe("Something went wrong, please try again");
+        expect(screen.getByRole("heading", { name: "Sorry" })).toBeInTheDocument();
+        expect(screen.getByText("Something went wrong, please try again")).toBeInTheDocument();
     });
 });

--- a/flashcards/web/vite.config.ts
+++ b/flashcards/web/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import eslint from "vite-eslint-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
 
@@ -15,10 +15,22 @@ export default defineConfig({
             functions: 80,
             branches: 80,
             statements: 80,
+            all: true,
+            include: ["src"],
+            exclude: [
+                "src/App.tsx",
+                "src/main.tsx",
+                "src/router.tsx",
+                "src/vite-env.d.ts",
+                "**/index.ts",
+                "**/types.ts",
+                "src/modules/common/i18nTranslation/config.ts",
+                "src/modules/genericTests",
+            ],
         },
     },
     server: {
-        port: parseInt(process.env.VITE_PORT),
+        port: parseInt(process.env.VITE_PORT, 10),
         host: "0.0.0.0",
     },
     plugins: [

--- a/quiz/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/quiz/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it } from "vitest";
+import { screen, render } from "@testing-library/react";
+import { ErrorBoundary } from "modules/common/components";
+
+describe("ErrorBoundary", () => {
+    it("Displays error message after catching error", () => {
+        const ThrowError = () => {
+            throw new Error("Random Error");
+        };
+
+        render(
+            <ErrorBoundary>
+                <ThrowError />
+            </ErrorBoundary>
+        );
+
+        expect(screen.getByRole("h1").textContent).toBe("Sorry");
+        expect(screen.getByRole("p").textContent).toBe("Something went wrong, please try again");
+    });
+});

--- a/quiz/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/quiz/web/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -14,7 +14,7 @@ describe("ErrorBoundary", () => {
             </ErrorBoundary>
         );
 
-        expect(screen.getByRole("h1").textContent).toBe("Sorry");
-        expect(screen.getByRole("p").textContent).toBe("Something went wrong, please try again");
+        expect(screen.getByRole("heading", { name: "Sorry" })).toBeInTheDocument();
+        expect(screen.getByText("Something went wrong, please try again")).toBeInTheDocument();
     });
 });

--- a/quiz/web/vite.config.ts
+++ b/quiz/web/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import eslint from "vite-eslint-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
 
@@ -15,10 +15,22 @@ export default defineConfig({
             functions: 80,
             branches: 80,
             statements: 80,
+            all: true,
+            include: ["src"],
+            exclude: [
+                "src/App.tsx",
+                "src/main.tsx",
+                "src/router.tsx",
+                "src/vite-env.d.ts",
+                "**/index.ts",
+                "**/types.ts",
+                "src/modules/common/i18nTranslation/config.ts",
+                "src/modules/genericTests",
+            ],
         },
     },
     server: {
-        port: parseInt(process.env.VITE_PORT),
+        port: parseInt(process.env.VITE_PORT, 10),
         host: "0.0.0.0",
     },
     plugins: [

--- a/templates/react/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/templates/react/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it } from "vitest";
+import { screen, render } from "@testing-library/react";
+import { ErrorBoundary } from "modules/common/components";
+
+describe("ErrorBoundary", () => {
+    it("Displays error message after catching error", () => {
+        const ThrowError = () => {
+            throw new Error("Random Error");
+        };
+
+        render(
+            <ErrorBoundary>
+                <ThrowError />
+            </ErrorBoundary>
+        );
+
+        expect(screen.getByRole("h1").textContent).toBe("Sorry");
+        expect(screen.getByRole("p").textContent).toBe("Something went wrong, please try again");
+    });
+});

--- a/templates/react/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/templates/react/src/modules/common/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -14,7 +14,7 @@ describe("ErrorBoundary", () => {
             </ErrorBoundary>
         );
 
-        expect(screen.getByRole("h1").textContent).toBe("Sorry");
-        expect(screen.getByRole("p").textContent).toBe("Something went wrong, please try again");
+        expect(screen.getByRole("heading", { name: "Sorry" })).toBeInTheDocument();
+        expect(screen.getByText("Something went wrong, please try again")).toBeInTheDocument();
     });
 });

--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -1,5 +1,5 @@
 import react from "@vitejs/plugin-react-swc";
-import { defineConfig } from "vite";
+import { defineConfig } from "vitest/config";
 import eslint from "vite-eslint-plugin";
 import tsconfigPaths from "vite-tsconfig-paths";
 
@@ -15,10 +15,22 @@ export default defineConfig({
             functions: 80,
             branches: 80,
             statements: 80,
+            all: true,
+            include: ["src"],
+            exclude: [
+                "src/App.tsx",
+                "src/main.tsx",
+                "src/router.tsx",
+                "src/vite-env.d.ts",
+                "**/index.ts",
+                "**/types.ts",
+                "src/modules/common/i18nTranslation/config.ts",
+                "src/modules/genericTests",
+            ],
         },
     },
     server: {
-        port: parseInt(process.env.VITE_PORT),
+        port: parseInt(process.env.VITE_PORT, 10),
         host: "0.0.0.0",
     },
     plugins: [


### PR DESCRIPTION
# Description
Coverage was not running properly in react template project, following PR fixes the problem so that 0% coverage is noted and reported correctly. Changes were made to `templates/react` , 'quiz/web`, `flashcards/web` directories. Additionally update obsolete `flashcards/web/eslintrc.json`.

[Youtrack](https://azeno.youtrack.cloud/issue/AQ-108/Fix-coverage-bug)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] The related memme has been added
![image](https://i.giphy.com/l0MYSpvx4pnsoMNz2.gif)

