### PR TITLE
AF-80 CustomUser model check: Duplicate key value issue

### DIFF
--- a/flashcards/backend/users/admin.py
+++ b/flashcards/backend/users/admin.py
@@ -11,6 +11,7 @@ class UserAdminConfig(UserAdmin):
     it can be changed in list_display class field.
     """
 
+    add_fieldsets = ((None, {"classes": ("wide",), "fields": ("email", "username", "password1", "password2")}),)
     model = User
     search_fields = ("email", "username")
     list_filter = ("email", "username", "is_active", "is_staff")

--- a/flashcards/backend/users/models.py
+++ b/flashcards/backend/users/models.py
@@ -82,7 +82,14 @@ class CustomUser(AbstractUser):
 
     id: models.UUIDField = models.UUIDField(default=uuid.uuid4, primary_key=True, editable=False, db_index=True)
     email = models.EmailField(_("email address"), unique=True)
-    username = models.CharField(max_length=100, validators=[UnicodeUsernameValidator()])
+    username = models.CharField(
+        max_length=100,
+        blank=True,
+        null=True,
+        unique=False,
+        validators=[UnicodeUsernameValidator()],
+        help_text="Optional",
+    )
 
     USERNAME_FIELD: str = "email"
     REQUIRED_FIELDS: list[str] = [


### PR DESCRIPTION
# Description

AF-80 user creation form in django admin to allow registering with email address, set username as non unique, non mandatory

YouTrack Task [Link](https://azeno.youtrack.cloud/issue/AF-80/CustomUser-model-check-Duplicate-key-value-issue)

Fixes # (issue)

Issue: 
Basic Django form for creating new user allows registering with only a username, when email address is set as unique login identifier. This leads to store empty string in email field and prevents from creating another user by functionality "Save and add another one."


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Manually tested in django admin

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] The related meme has been added

![Meme](https://media.giphy.com/media/gG6OcTSRWaSis/giphy.gif)
