### PR TITLE
FM-55 type annotations for factories

### DIFF
--- a/flashcards/backend/decks/factories.py
+++ b/flashcards/backend/decks/factories.py
@@ -17,7 +17,7 @@ class CategoryFactory(DjangoModelFactory):
         django_get_or_create = ("name",)
 
     name = Sequence(lambda n: f"Category {n:0>4}")
-    description = Faker("sentence", nb_words=5)
+    description: Faker = Faker("sentence", nb_words=5)
 
 
 class DifficultyLevelFactory(DjangoModelFactory):
@@ -31,8 +31,8 @@ class DifficultyLevelFactory(DjangoModelFactory):
         model = DifficultyLevel
         django_get_or_create = ("value",)
 
-    value = Faker("pyint", min_value=1, max_value=10)
-    name = LazyAttribute(lambda a: "Difficulty " + str(a.value))
+    value: Faker = Faker("pyint", min_value=1, max_value=10)
+    name: LazyAttribute = LazyAttribute(lambda a: "Difficulty " + str(a.value))
 
 
 class DeckFactory(DjangoModelFactory):
@@ -46,15 +46,15 @@ class DeckFactory(DjangoModelFactory):
         model = Deck
 
     image = ImageField(color="blue")
-    name = Faker("language_name")
-    category = SubFactory(CategoryFactory)
-    difficulty_level = SubFactory(DifficultyLevelFactory)
+    name: Faker = Faker("language_name")
+    category: SubFactory = SubFactory(CategoryFactory)
+    difficulty_level: SubFactory = SubFactory(DifficultyLevelFactory)
     is_public = True
-    price = Faker("pydecimal", right_digits=2, min_value=1, max_value=99)
-    author = SubFactory(UserFactory)
+    price: Faker = Faker("pydecimal", right_digits=2, min_value=1, max_value=99)
+    author: SubFactory = SubFactory(UserFactory)
     popularity = 0
     is_active = True
-    description = Faker("sentence", nb_words=8)
+    description: Faker = Faker("sentence", nb_words=8)
 
 
 class FlashcardFactory(DjangoModelFactory):
@@ -74,6 +74,6 @@ class TagFactory(DjangoModelFactory):
     class Meta:
         model = Tag
 
-    name = Faker("bothify", text="Tag_???-###")
-    deck = SubFactory(DeckFactory)
-    flashcard = SubFactory(FlashcardFactory)
+    name: Faker = Faker("bothify", text="Tag_???-###")
+    deck: SubFactory = SubFactory(DeckFactory)
+    flashcard: SubFactory = SubFactory(FlashcardFactory)

--- a/flashcards/backend/poetry.lock
+++ b/flashcards/backend/poetry.lock
@@ -483,7 +483,7 @@ files = [
 name = "factory-boy"
 version = "3.2.1"
 description = "A versatile test fixtures replacement based on thoughtbot's factory_bot for Ruby."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 files = [
@@ -502,7 +502,7 @@ doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 name = "faker"
 version = "17.6.0"
 description = "Faker is a Python package that generates fake data for you."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -974,7 +974,7 @@ testing = ["Django", "django-configurations (>=2.0)"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
@@ -1072,7 +1072,7 @@ testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 files = [
@@ -1297,7 +1297,7 @@ files = [
 name = "types-factory-boy"
 version = "0.4.1"
 description = "Typing stubs for factory-boy"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1404,4 +1404,4 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "f063d0db808ae730f33f854c545085ce78a6c28d620240af247515558c0e819d"
+content-hash = "072a5b4e7f45fca55644c4b76bb67eb62cb8218a28ee22478f1e98e77f753252"

--- a/flashcards/backend/pyproject.toml
+++ b/flashcards/backend/pyproject.toml
@@ -20,6 +20,7 @@ python-magic = "0.4.27"
 pillow = "9.4.0"
 psycopg = "3.1.8"
 django-filter = "23.1"
+types-factory-boy = "0.4.1"
 
 [tool.poetry.group.dev.dependencies]
 sphinx = "6.1.3"


### PR DESCRIPTION
# Description

Added type annotation package for mypy to identify them. However, for Faker objects the package doesn't work correctly | [described in the issue by the package author](https://github.com/youtux/types-factory-boy/issues/7)
In the file factories.py annotations were added manually where it was necessary to avoid errors raised by mypy.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Unit test, manually created test data by running custom command for factories.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] The related memme has been added

![meme](https://media.giphy.com/media/JWuBH9rCO2uZuHBFpm/giphy.gif)
